### PR TITLE
Style object now gets passed to the rendered dom element

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ How long to delay the animation for (in milliseconds) once it enters or leaves t
 
 Whether the element should only animate once or not.
 
+**style** - default {}
+
+A style object can be assigned to any ScrollAnimation component and will be passed to the rendered dom element. Its probably best to avoid manually setting animationDuration or opacity as the component will modify those attributes.
+
 **afterAnimatedIn**
 
 Callback function to run once the animateIn animation has completed. Receives the visibility of the element at time of execution.
@@ -97,6 +101,10 @@ function(visible) {
 ```
 
 ## Changes:
+### Version 2.0.2
+* ScrollAnimation components now accept style prop.
+### Version 2.0.1
+* animateOnce now works properly.
 #### Version 2.0.0
 * The "visible" object passed to the afterAnimatedIn and afterAnimatedOut callbacks has the properties "onScreen" which is true if the element is on the screen, and "inViewport", which is true if the element is in the viewport. visible.completely and visible.partially will no longer work.
 * Should now work on mobile devices.

--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -204,5 +204,5 @@ ScrollAnimation.propTypes = {
   delay: PropTypes.number,
   initiallyVisible: PropTypes.bool,
   animateOnce: PropTypes.bool,
-  style: Proptype.object
+  style: Proptypes.object
 };

--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -204,5 +204,5 @@ ScrollAnimation.propTypes = {
   delay: PropTypes.number,
   initiallyVisible: PropTypes.bool,
   animateOnce: PropTypes.bool,
-  style: Proptypes.object
+  style: PropTypes.object
 };

--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -181,7 +181,7 @@ export default class ScrollAnimation extends Component {
 
   render() {
     return (
-      <div ref={(node) => { this.node = node; }} className={this.state.classes} style={this.state.style}>
+      <div ref={(node) => { this.node = node; }} className={this.state.classes} style={Object.assign(this.state.style, this.props.style)}>
         {this.props.children}
       </div>
     );
@@ -203,5 +203,6 @@ ScrollAnimation.propTypes = {
   duration: PropTypes.number,
   delay: PropTypes.number,
   initiallyVisible: PropTypes.bool,
-  animateOnce: PropTypes.bool
+  animateOnce: PropTypes.bool,
+  style: Proptype.object
 };

--- a/src/scroll-animation.test.js
+++ b/src/scroll-animation.test.js
@@ -805,6 +805,11 @@ describe("ScrollAnimation - ", function () {
       });
   });
 
+  it("passes the style prop to the rendered dom element", () => {
+    ReactDOM.render(<ScrollAnimation animateIn="fadeIn" duration={2} style={{color: "red"}}/>, myTestDiv);
+    expect(document.getElementsByTagName("div")[1].style["color"]).toBe("red");
+  });
+
   function createScrollAnimationOffScreen(props) {
     var size = props.size ? props.size : 100;
     ReactDOM.render(<div><div style={{height:10000 + "px"}} /><div id="test"/><div style={{height:10000 + "px"}} /></div>, myTestDiv);


### PR DESCRIPTION
Cleaned up my PR a bit based on your suggestions.

Users can now use the style prop on ScrollAnimation components. The style object will be passed to the rendered dom element.

So you can now style ScrollAnimations inline if you wish by doing:
`<ScrollAnimation animateIn="fadeIn" duration={0.5}  style={{ color: 'red' }}>`