### PR TITLE
Update scroll-animation.js

### DIFF
--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -195,7 +195,7 @@ export default class ScrollAnimation extends Component {
 
   render() {
     return (
-      <div ref={(node) => { this.node = node; }} className={this.state.classes} style={Object.assign(this.state.style, this.props.style)}>
+      <div ref={(node) => { this.node = node; }} className={this.state.classes} style={Object.assign({}, this.state.style, this.props.style)}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
Object.assign mutates its first parameter and you shouldn't mutate this.state directly. To avoid this just pass a blank object as the first parameter.