### PR TITLE
update peer dependency to prevent the need of --force or --legacy-peer-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "http://dbramwell.github.io/react-animate-on-scroll",
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "react": ">= 15.4.1 < 17.0.0-0"
+    "react": ">= 15.4.1 < 19.0.0-0"
   },
   "devDependencies": {
     "animate.css": "^3.5.2",


### PR DESCRIPTION
Currently the `npm i` will cause the error as follow:


```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: react-animate-on-scroll@2.1.7
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   peer react@"^18.0.0" from @tanstack/react-query@5.22.2
npm ERR!   node_modules/@tanstack/react-query
npm ERR!     @tanstack/react-query@"^5.22.2" from the root project
npm ERR!     peer @tanstack/react-query@"^5.22.2" from @tanstack/react-query-devtools@5.24.0
npm ERR!     node_modules/@tanstack/react-query-devtools
npm ERR!       @tanstack/react-query-devtools@"^5.24.0" from the root project
npm ERR!   peer react@"^16.8 || ^17.0 || ^18.0" from @radix-ui/react-portal@1.0.3
npm ERR!   node_modules/@radix-ui/react-portal
npm ERR!     @radix-ui/react-portal@"1.0.3" from @radix-ui/react-select@1.2.2
npm ERR!     node_modules/@radix-ui/react-select
npm ERR!       @radix-ui/react-select@"^1.2.2" from @storybook/components@7.6.7
npm ERR!       node_modules/@storybook/components
npm ERR!         @storybook/components@"^7.0.0" from storybook-dark-mode@3.0.3
npm ERR!         node_modules/storybook-dark-mode
npm ERR!   64 more (react-dropzone-esm, @radix-ui/react-use-size, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@">= 15.4.1 < 17.0.0-0" from react-animate-on-scroll@2.1.7
npm ERR! node_modules/react-animate-on-scroll
npm ERR!   react-animate-on-scroll@"^2.1.7" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: react@16.14.0
npm ERR! node_modules/react
npm ERR!   peer react@">= 15.4.1 < 17.0.0-0" from react-animate-on-scroll@2.1.7
npm ERR!   node_modules/react-animate-on-scroll
npm ERR!     react-animate-on-scroll@"^2.1.7" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR!
npm ERR! For a full report see:
npm ERR! C:\Users\hansy\AppData\Local\npm-cache\_logs\2024-04-24T09_52_57_303Z-eresolve-report.txt
```

The current work arround is to use `--force` or `--legacy-peer-deps` flag. but for more convenience, the package still work on react 18.2, lets just update the peer deps for now